### PR TITLE
Fix issues with Safari

### DIFF
--- a/src/assets/constants.js
+++ b/src/assets/constants.js
@@ -29,7 +29,7 @@ export const shareChars = { wrong: "🟥", skip: "🟥", right: "🟩", partial:
 // Modal options
 export const modalIds = { about: "about-modal", stats: "stats-modal" }
 export const modalFadeDelay = [50, 100] // [OPEN ms, CLOSE ms]
-export const autoShowStatsDelay = 3000
+export const autoShowStatsDelay = 1500
 
 // Guess list options
 export const guessColumns = 2

--- a/src/components/styles/StatsStyles.js
+++ b/src/components/styles/StatsStyles.js
@@ -33,8 +33,8 @@ const StatsButton = ({ onClick, label, children }) => (
     flex flex-wrap-reverse gap-0 sm:gap-4 place-content-start justify-center 
     ${!onClick ? 'btn-inactive' : ''}
   `}>
-    {!!label && <span className="text-lg sm:text-2xl">{label}</span>}
-    {children}
+    {!!label && <div className="text-lg sm:text-2xl">{label}</div>}
+    <div className="py-2 pl-1 sm:pl-0 sm:py-3 h-full">{children}</div>
   </button>
 )
 
@@ -45,23 +45,25 @@ export const StatsDivider = () => (
 
 export const ShareButton = ({ onClick }) => (
   <StatsButton onClick={onClick} label="Share">
-    <ShareIcon className="fill-current w-auto h-full py-2 pl-1 sm:pl-0 sm:py-3" />
+    <ShareIcon className="fill-current w-auto h-full" />
   </StatsButton>
 )
 
 export const NewGameButton = ({ onClick }) => (
   <StatsButton onClick={onClick} label="New Game">
-    <NewGameIcon className="fill-current w-auto h-full py-2 pl-1 sm:pl-0 sm:py-3" />
+    <NewGameIcon className="fill-current w-auto h-full" />
   </StatsButton>
 )
 
 export const StatsTimerStyle = ({ label, children }) => (
-  <StatsButton>
-    <div className="flex flex-row sm:flex-col justify-center items-center gap-2 sm:gap-1">
+  <StatsButton label={
+    <div className="flex flex-row sm:flex-col justify-center items-center
+      gap-2 sm:gap-1 text-sm sm:text-lg sm:leading-4">
       <div className="font-sans uppercase">{label}</div>
       <div className="font-mono font-light">{children}</div>
     </div>
-    <NewGameIcon className="fill-current w-auto h-full py-2 pl-1 sm:pl-0 sm:py-3" />
+  }>
+    <NewGameIcon className="fill-current w-auto h-full" />
   </StatsButton>
 )
 

--- a/src/services/subservices/share.services.js
+++ b/src/services/subservices/share.services.js
@@ -1,14 +1,20 @@
 import { shareDefaults, shareChars } from "../../assets/constants"
 import { blankArray }  from "../app.controller"
 
+// Force clipboard API on MacOS Safari to avoid their frustratingly stupid sharing extension
+const forceClipboard = () => /^((?!chrome|android|ip(hone|pod)|mobile).)*safari/i.test(navigator.userAgent)
+
 async function shareData(text, title = shareDefaults.title, url = shareDefaults.url) {
-  const canShare = Boolean(window.navigator.share)
-  if (canShare) {
-    await window.navigator.share({ title, url, text }).catch(() => {})
+  text = text + '\n' + url
+  if (window.navigator.share && !forceClipboard()) {
+    await window.navigator.share({ title, text }).catch(() => {})
+    return false
   } else if (Boolean(window.navigator.clipboard?.writeText)) {
-    await window.navigator.clipboard.writeText(text + '\n' + url)
-  } else return shareDefaults.failMsg
-  return !canShare && shareDefaults.copyMsg
+    await window.navigator.clipboard.writeText(text)
+    return shareDefaults.copyMsg
+  } else {
+    return shareDefaults.failMsg
+  }
 }
 
 const shareScore = (guesses, guessCount, date, setAlert) => shareData(


### PR DESCRIPTION
Fixed button layouts overflowing due to order which width/height % vs padding are calculated in Safari browser on Mac OS.

Added workaround that avoids the Mac OS Sharing Extension in Safari because it doesn't allow you to copy the shared object and also ignores the 'text' property if called with a 'url' property.

(Also cut the time before the Stats menu pops up once the game is finished in half because it was annoying me.)